### PR TITLE
Improved support for "Content-Disposition".

### DIFF
--- a/src/DOMPDFModule/View/Strategy/PdfStrategy.php
+++ b/src/DOMPDFModule/View/Strategy/PdfStrategy.php
@@ -126,7 +126,7 @@ class PdfStrategy implements ListenerAggregateInterface
             
             $response->getHeaders()->addHeaderLine(
             	'Content-Disposition', 
-            	'attachment; filename=' . $fileName);
+            	'attachment; filename="' . $fileName . '"');
         }
     }
 }


### PR DESCRIPTION
"Content-Disposition" header is ignored in its classic format, like `Content-Disposition: attachment; filename=my-file.pdf`, by some browsers versions. Wrapping filename by inverted commas, like `Content-Disposition: attachment; filename="my-file.pdf"` helps avoiding this kind of problems.
