### PR TITLE
Limit zend-mvc version to avoid BC breaks.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
         "zendframework/zend-loader": "^2.1.6",
         "zendframework/zend-servicemanager": "^2.1.6",
         "zendframework/zend-modulemanager": "^2.1.6",
-        "zendframework/zend-mvc": "^2.1.6",
+        "zendframework/zend-mvc": "^2.1.6 <2.7",
         "zendframework/zend-view": "^2.1.6",
         "zendframework/zend-serializer": "^2.1.6",
         "zendframework/zend-log": "^2.1.6",
         "zendframework/zend-i18n": "^2.1.6",
         "zendframework/zend-http": "^2.1.6",
-        "dompdf/dompdf": "^0.6.0",
-        "zendframework/zend-console": "2.5.0"
+        "zendframework/zend-console": "^2.1.6",
+        "dompdf/dompdf": "^0.6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.27",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "a99474b87097d42c8c7700cdbe796094",
+    "content-hash": "816379d996fa6452c7087bc49d24371a",
     "packages": [
         {
             "name": "dompdf/dompdf",
@@ -83,28 +83,28 @@
         },
         {
             "name": "zendframework/zend-console",
-            "version": "2.5.0",
+            "version": "2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-console.git",
-                "reference": "59b467b36c40b767e3c1bac1310031073f00ce28"
+                "reference": "ad425c45444a76d6559df45df14291940c6883f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-console/zipball/59b467b36c40b767e3c1bac1310031073f00ce28",
-                "reference": "59b467b36c40b767e3c1bac1310031073f00ce28",
+                "url": "https://api.github.com/repos/zendframework/zend-console/zipball/ad425c45444a76d6559df45df14291940c6883f1",
+                "reference": "ad425c45444a76d6559df45df14291940c6883f1",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.23",
-                "zendframework/zend-stdlib": "~2.5.0"
+                "zendframework/zend-stdlib": "~2.5"
             },
             "require-dev": {
                 "fabpot/php-cs-fixer": "1.7.*",
                 "phpunit/phpunit": "~4.0",
-                "zendframework/zend-filter": "~2.5.0",
-                "zendframework/zend-json": "~2.5.0",
-                "zendframework/zend-validator": "~2.5.0"
+                "zendframework/zend-filter": "~2.5",
+                "zendframework/zend-json": "~2.5",
+                "zendframework/zend-validator": "~2.5"
             },
             "suggest": {
                 "zendframework/zend-filter": "To support DefaultRouteMatcher usage",
@@ -131,7 +131,7 @@
                 "console",
                 "zf2"
             ],
-            "time": "2015-06-03T14:05:33+00:00"
+            "time": "2015-06-03T15:32:00+00:00"
         },
         {
             "name": "zendframework/zend-escaper",


### PR DESCRIPTION
This fix accommodates the BC break as mentioned in issue  #37.