### PR TITLE
Added default PDF file name.

### DIFF
--- a/src/DOMPDFModule/View/Model/PdfModel.php
+++ b/src/DOMPDFModule/View/Model/PdfModel.php
@@ -31,7 +31,7 @@ class PdfModel extends ViewModel
         'paperSize' => '8x11',
         'paperOrientation' => 'portrait',
         'basePath' => '/',
-        'fileName' => null
+        'fileName' => 'untitled.pdf'
     );
 
     /**

--- a/tests/DOMPDFModuleTest/View/Model/PdfModelTest.php
+++ b/tests/DOMPDFModuleTest/View/Model/PdfModelTest.php
@@ -47,7 +47,7 @@ class PdfModelTest extends \PHPUnit_Framework_TestCase
 
     public function testItHasDefaultFileName()
     {
-        $this->assertNull($this->model->getOption('fileName'));
+        $this->assertEquals('untitled.pdf', $this->model->getOption('fileName'));
     }
 
     public function testItIsTerminal()


### PR DESCRIPTION
## Change Profile

| Question      | Answer
| ------------- | ---
| New feature   | yes
| Bug fix       | no
| BC breaks     | no
| Passing tests | yes

## Description
Set default file name to "untitled.pdf".

## Reason
Having a "null" file name is strange and will cause unexpected side effects when not provided to the PdfModel view model.
