### PR TITLE
Fixed filename option to correctly be fileName.

### DIFF
--- a/src/DOMPDFModule/View/Strategy/PdfStrategy.php
+++ b/src/DOMPDFModule/View/Strategy/PdfStrategy.php
@@ -118,7 +118,7 @@ class PdfStrategy implements ListenerAggregateInterface
         $response->setContent($result);
         $response->getHeaders()->addHeaderLine('content-type', 'application/pdf');
         
-        $fileName = $event->getModel()->getOption('filename');
+        $fileName = $event->getModel()->getOption('fileName');
         if (isset($fileName)) {
             if (substr($fileName, -4) != '.pdf') {
                 $fileName .= '.pdf';

--- a/tests/DOMPDFModuleTest/View/Strategy/PdfStrategyTest.php
+++ b/tests/DOMPDFModuleTest/View/Strategy/PdfStrategyTest.php
@@ -115,7 +115,7 @@ class PdfStrategyTest extends TestCase
     {
         $model = new PdfModel();
         $model->setTemplate('basic.phtml');
-        $model->setOption('filename', 'testPdfFileName');
+        $model->setOption('fileName', 'testPdfFileName');
         
         $this->event->setModel($model);
         $this->event->setResponse($this->response);


### PR DESCRIPTION
## Change Profile

| Question      | Answer
| ------------- | ---
| New feature   | no
| Bug fix       | yes
| BC breaks     | no
| Passing tests | yes

## Description
Fix file name option to correctly be "fileName" vs "filename".

## Reason
https://github.com/raykolbe/DOMPDFModule/issues/19 describes a bug where file name is not correctly passed to header.
