### PR TITLE
Added safeguard to PdfRenderer to enforce PdfModel support only.

### DIFF
--- a/src/DOMPDFModule/View/Renderer/PdfRenderer.php
+++ b/src/DOMPDFModule/View/Renderer/PdfRenderer.php
@@ -19,6 +19,8 @@
 
 namespace DOMPDFModule\View\Renderer;
 
+use DOMPDFModule\View\Model\PdfModel;
+use Zend\View\Exception\InvalidArgumentException;
 use Zend\View\Renderer\RendererInterface as Renderer;
 use Zend\View\Resolver\ResolverInterface as Resolver;
 use DOMPDF;
@@ -45,7 +47,12 @@ class PdfRenderer implements Renderer
         $this->dompdf = $dompdf;
         return $this;
     }
-    
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return DOMPDF
+     */
     public function getEngine()
     {
         return $this->dompdf;
@@ -60,6 +67,14 @@ class PdfRenderer implements Renderer
      */
     public function render($nameOrModel, $values = null)
     {
+        if (!($nameOrModel instanceof PdfModel)) {
+            throw new InvalidArgumentException(sprintf(
+                '%s expects a PdfModel as the first argument; received "%s"',
+                __METHOD__,
+                (is_object($nameOrModel) ? get_class($nameOrModel) : gettype($nameOrModel))
+            ));
+        }
+
         $html = $this->getHtmlRenderer()->render($nameOrModel, $values);
         
         $paperSize = $nameOrModel->getOption('paperSize');

--- a/tests/DOMPDFModuleTest/View/Renderer/PdfRendererTest.php
+++ b/tests/DOMPDFModuleTest/View/Renderer/PdfRendererTest.php
@@ -1,0 +1,116 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Raymond J. Kolbe <rkolbe@gmail.com>
+ * @copyright Copyright (c) 2017 Raymond J. Kolbe
+ * @license	http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace DOMPDFModuleTest\View\Strategy;
+
+use Zend\View\Model\JsonModel;
+use DOMPDFModuleTest\Framework\TestCase;
+use DOMPDFModule\View\Model\PdfModel;
+use DOMPDFModule\View\Renderer\PdfRenderer;
+
+class PdfRendererTest extends TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $htmlRenderer;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $engine;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $resolver;
+
+    /**
+     * System under test.
+     *
+     * @var PdfRenderer
+     */
+    private $renderer;
+
+    public function testItHasAnHtmlRenderer()
+    {
+        $this->assertInstanceOf('Zend\View\Renderer\RendererInterface', $this->renderer->getHtmlRenderer());
+    }
+
+    public function testItHasAnEngine()
+    {
+        $this->assertInstanceOf('DOMPDF', $this->renderer->getEngine());
+    }
+
+    public function testItRendersAPdfModel()
+    {
+        $this->htmlRenderer->expects($this->once())->method('render');
+
+        $this->engine->expects($this->once())->method('set_paper');
+        $this->engine->expects($this->once())->method('set_base_path');
+        $this->engine->expects($this->once())->method('load_html');
+        $this->engine->expects($this->once())->method('render');
+        $this->engine->expects($this->once())->method('output');
+
+        $this->renderer->render(new PdfModel());
+    }
+
+    /**
+     * @expectedException \Zend\View\Exception\InvalidArgumentException
+     */
+    public function testItDoesNotRenderOtherModels()
+    {
+        $this->htmlRenderer->expects($this->never())->method('render');
+
+        $this->engine->expects($this->never())->method('render');
+        $this->engine->expects($this->never())->method('output');
+
+        $this->renderer->render(new JsonModel());
+    }
+
+    /**
+     * @expectedException \Zend\View\Exception\InvalidArgumentException
+     */
+    public function testItDoesNotRenderNamedModels()
+    {
+        $this->htmlRenderer->expects($this->never())->method('render');
+
+        $this->engine->expects($this->never())->method('render');
+        $this->engine->expects($this->never())->method('output');
+
+        $this->renderer->render('named-model');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->htmlRenderer = $this->getMock('Zend\View\Renderer\RendererInterface');
+        $this->resolver = $this->getMock('Zend\View\Resolver\ResolverInterface');
+        $this->engine = $this->getMockBuilder('DOMPDF')->disableOriginalConstructor()->getMock();
+
+        $this->renderer = new PdfRenderer();
+        $this->renderer->setHtmlRenderer($this->htmlRenderer);
+        $this->renderer->setResolver($this->resolver);
+        $this->renderer->setEngine($this->engine);
+    }
+}


### PR DESCRIPTION
## Change Profile

| Question      | Answer
| ------------- | ---
| New feature   | yes
| Bug fix       | no
| BC breaks     | no
| Passing tests | yes

## Description
Add safeguard to PDF Renderer to strictly support PdfModel rendering only.

## Reason
By forcing the renderer to use PdfModel we can ensure that the options used from the view model have a default. We can also guarantee that captureTo and terminate properties are correctly set thus avoiding unintended side effects during rendering.

It is important to note that this has been the intended usage of this module until a use-case worthy of implementation is presented, hence why this change is listed as a "no BC breaks".