### PR TITLE
Added the ability to control how PDF is streamed to browser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ class ReportController extends AbstractActionController
     public function monthlyReportPdfAction()
     {
         $pdf = new PdfModel();
-        $pdf->setOption('fileName', 'monthly-report'); // Triggers PDF download, automatically appends ".pdf"
-        $pdf->setOption('paperSize', 'a4'); // Defaults to "8x11"
-        $pdf->setOption('paperOrientation', 'landscape'); // Defaults to "portrait"
+        $pdf->setOption('fileName', 'monthly-report');            // "pdf" extension is automatically appended
+        $pdf->setOption('display', PdfModel::DISPLAY_ATTACHMENT); // Triggers browser to prompt "save as" dialog
+        $pdf->setOption('paperSize', 'a4');                       // Defaults to "8x11"
+        $pdf->setOption('paperOrientation', 'landscape');         // Defaults to "portrait"
         
         // To set view variables
         $pdf->setVariables(array(

--- a/src/DOMPDFModule/View/Model/PdfModel.php
+++ b/src/DOMPDFModule/View/Model/PdfModel.php
@@ -23,6 +23,10 @@ use Zend\View\Model\ViewModel;
 
 class PdfModel extends ViewModel
 {
+    const DISPLAY_INLINE = 'inline';
+    const DISPLAY_ATTACHMENT = 'attachment';
+    const DEFAULT_FILE_NAME = 'untitled.pdf';
+
     /**
      * Renderer options
      * @var array
@@ -31,7 +35,8 @@ class PdfModel extends ViewModel
         'paperSize' => '8x11',
         'paperOrientation' => 'portrait',
         'basePath' => '/',
-        'fileName' => 'untitled.pdf'
+        'fileName' => self::DEFAULT_FILE_NAME,
+        'display' => self::DISPLAY_INLINE
     );
 
     /**

--- a/src/DOMPDFModule/View/Strategy/PdfStrategy.php
+++ b/src/DOMPDFModule/View/Strategy/PdfStrategy.php
@@ -108,26 +108,27 @@ class PdfStrategy implements ListenerAggregateInterface
         }
 
         $result = $event->getResult();
-
         if (!is_string($result)) {
-            // @todo Potentially throw an exception here since we should *always* get back a result.
+            // No output to display. Good bye!
             return;
         }
         
         $response = $event->getResponse();
         $response->setContent($result);
-        $response->getHeaders()->addHeaderLine('content-type', 'application/pdf');
-        
-        $fileName = $event->getModel()->getOption('fileName');
-        if (isset($fileName)) {
-            if (substr($fileName, -4) != '.pdf') {
-                $fileName .= '.pdf';
-            }
-            
-            $response->getHeaders()->addHeaderLine(
-                'Content-Disposition',
-                'attachment; filename=' . $fileName
-            );
+
+        $model   = $event->getModel();
+        $options = $model->getOptions();
+
+        $fileName        = $options['fileName'];
+        $dispositionType = $options['display'];
+
+        if (substr($fileName, -4) != '.pdf') {
+            $fileName .= '.pdf';
         }
+
+        $headerValue = sprintf('%s; filename="%s"', $dispositionType, $fileName);
+
+        $response->getHeaders()->addHeaderLine('Content-Type', 'application/pdf');
+        $response->getHeaders()->addHeaderLine('Content-Disposition', $headerValue);
     }
 }

--- a/tests/DOMPDFModuleTest/View/Model/PdfModelTest.php
+++ b/tests/DOMPDFModuleTest/View/Model/PdfModelTest.php
@@ -50,6 +50,11 @@ class PdfModelTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('untitled.pdf', $this->model->getOption('fileName'));
     }
 
+    public function testItHasDefaultDisplayOption()
+    {
+        $this->assertEquals(PdfModel::DISPLAY_INLINE, $this->model->getOption('display'));
+    }
+
     public function testItIsTerminal()
     {
         $this->assertTrue($this->model->terminate());

--- a/tests/DOMPDFModuleTest/View/Strategy/PdfStrategyTest.php
+++ b/tests/DOMPDFModuleTest/View/Strategy/PdfStrategyTest.php
@@ -90,7 +90,7 @@ class PdfStrategyTest extends TestCase
         $this->assertNull($result);
     }
     
-    public function testContentTypeResponseHeader()
+    public function testItAddsApplicationPdfContentType()
     {
         $model = new PdfModel();
         $model->setTemplate('basic.phtml');
@@ -103,7 +103,7 @@ class PdfStrategyTest extends TestCase
         $this->strategy->injectResponse($this->event);
         
         $headers           = $this->event->getResponse()->getHeaders();
-        $contentTypeHeader = $headers->get('content-type');
+        $contentTypeHeader = $headers->get('Content-Type');
         
         $this->assertInstanceOf('Zend\Http\Header\ContentType', $contentTypeHeader);
         $this->assertEquals($contentTypeHeader->getFieldValue(), 'application/pdf');
@@ -111,11 +111,12 @@ class PdfStrategyTest extends TestCase
         ob_end_flush(); // Clear out any buffers held by renderers.
     }
     
-    public function testResponseHeadersWithFileName()
+    public function testItAddsAttachmentDispositionType()
     {
         $model = new PdfModel();
         $model->setTemplate('basic.phtml');
         $model->setOption('fileName', 'testPdfFileName');
+        $model->setOption('display', PdfModel::DISPLAY_ATTACHMENT);
         
         $this->event->setModel($model);
         $this->event->setResponse($this->response);
@@ -124,11 +125,34 @@ class PdfStrategyTest extends TestCase
         
         $this->strategy->injectResponse($this->event);
         
-        $headers = $this->event->getResponse()->getHeaders();
+        $headers            = $this->event->getResponse()->getHeaders();
         $contentDisposition = $headers->get('Content-Disposition');
         
         $this->assertInstanceOf('Zend\Http\Header\ContentDisposition', $contentDisposition);
-        $this->assertEquals($contentDisposition->getFieldValue(), 'attachment; filename=testPdfFileName.pdf');
+        $this->assertEquals($contentDisposition->getFieldValue(), 'attachment; filename="testPdfFileName.pdf"');
+
+        ob_end_flush(); // Clear out any buffers held by renderers.
+    }
+
+    public function testItAddsInlineDispositionType()
+    {
+        $model = new PdfModel();
+        $model->setTemplate('basic.phtml');
+        $model->setOption('fileName', 'testPdfFileName');
+        $model->setOption('display', PdfModel::DISPLAY_INLINE);
+
+        $this->event->setModel($model);
+        $this->event->setResponse($this->response);
+        $this->event->setRenderer($this->renderer);
+        $this->event->setResult($this->renderer->render($model));
+
+        $this->strategy->injectResponse($this->event);
+
+        $headers            = $this->event->getResponse()->getHeaders();
+        $contentDisposition = $headers->get('Content-Disposition');
+
+        $this->assertInstanceOf('Zend\Http\Header\ContentDisposition', $contentDisposition);
+        $this->assertEquals($contentDisposition->getFieldValue(), 'inline; filename="testPdfFileName.pdf"');
 
         ob_end_flush(); // Clear out any buffers held by renderers.
     }


### PR DESCRIPTION
## Change Profile

| Question      | Answer
| ------------- | ---
| New feature   | yes
| Bug fix       | no
| BC breaks     | yes
| Passing tests | yes

## Description
Adds the ability to control how the file is streamed to the browser via Content-Disposition header.

## Reason
Allow for "inline" streaming to browser in order to compensate for a previous change that broke this implied streaming method. See https://github.com/raykolbe/DOMPDFModule/pull/64.
