### PR TITLE
Add support for Content-Length header in HTTP response.

### DIFF
--- a/src/DOMPDFModule/View/Strategy/PdfStrategy.php
+++ b/src/DOMPDFModule/View/Strategy/PdfStrategy.php
@@ -128,7 +128,8 @@ class PdfStrategy implements ListenerAggregateInterface
 
         $headerValue = sprintf('%s; filename="%s"', $dispositionType, $fileName);
 
-        $response->getHeaders()->addHeaderLine('Content-Type', 'application/pdf');
         $response->getHeaders()->addHeaderLine('Content-Disposition', $headerValue);
+        $response->getHeaders()->addHeaderLine('Content-Length', strlen($result));
+        $response->getHeaders()->addHeaderLine('Content-Type', 'application/pdf');
     }
 }


### PR DESCRIPTION
## Change Profile

| Question      | Answer
| ------------- | ---
| New feature   | yes
| Bug fix       | no
| BC breaks     | no
| Passing tests | yes

## Description
Add Content-Length header during HTTP response.

## Reason
Provide a means of knowing the size of the PDF file. This PR supersedes https://github.com/raykolbe/DOMPDFModule/pull/31
