### PR TITLE
Fix PHP version check.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -39,8 +39,8 @@ which php &> /dev/null || {
     exit 1
 }
 
-# Ensure supported PHP version (5.3.29+)
-php -r 'exit((int) !(PHP_VERSION_ID >= 50329));' || {
+# Ensure supported PHP version (5.6.0+)
+php -r 'exit((int) !(PHP_VERSION_ID >= 50600));' || {
     echo 'Unsupported version of PHP. Aborting build.'
     exit 1
 }


### PR DESCRIPTION
## Change Profile

| Question      | Answer
| ------------- | ---
| New feature   | no
| Bug fix       | yes
| BC breaks     | no
| Passing tests | yes

## Description
Set correct minimum version of PHP to check for.

## Reason
This was a missed update when PHP LTS version was considered.